### PR TITLE
Vaadin 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>7.4.11-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -11,16 +11,12 @@
     </organization>
 
     <scm>
-        <url>git://github.com/mstahv/easyuploads.git</url>
-        <connection>scm:git:git://github.com/mstahv/easyuploads.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:/mstahv/easyuploads.git</developerConnection>
-        <tag>vaadin upload add-on</tag>
+        <url>git://github.com/WoozyG/easyuploads.git</url>
+        <connection>scm:git:git://github.com/WoozyG/easyuploads.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:/WoozyG/easyuploads.git</developerConnection>
+        <tag>vaadin upload add-on for Vaadin 8</tag>
     </scm>
 
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/mstahv/easyuploads/issues</url>
-    </issueManagement>
 
     <licenses>
         <license>
@@ -33,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.7.4</vaadin.version>
+        <vaadin.version>8.0.0</vaadin.version>
     </properties>
 
     <build>
@@ -47,8 +43,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
@@ -142,6 +138,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+							<extraJvmArgs>-Xmx1G</extraJvmArgs>
                             <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
@@ -294,6 +291,30 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-server</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-client</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        
+		<dependency>
+		    <groupId>commons-io</groupId>
+		    <artifactId>commons-io</artifactId>
+		    <version>2.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+		    <version>3.5</version>
+		</dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-themes</artifactId>
             <version>${vaadin.version}</version>
             <scope>test</scope>
@@ -337,12 +358,14 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+<!--
         <dependency>
             <groupId>org.vaadin</groupId>
             <artifactId>viritin</artifactId>
             <version>1.53</version>
             <type>jar</type>
         </dependency>
+-->
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>8.0.2-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>8.0.0</vaadin.version>
+        <vaadin.version>8.0.2</vaadin.version>
     </properties>
 
     <build>
@@ -290,18 +290,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-client</artifactId>
-            <version>${vaadin.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-compatibility-server</artifactId>
-            <version>${vaadin.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-compatibility-client</artifactId>
             <version>${vaadin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,16 @@
     </organization>
 
     <scm>
-        <url>git://github.com/WoozyG/easyuploads.git</url>
-        <connection>scm:git:git://github.com/WoozyG/easyuploads.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:/WoozyG/easyuploads.git</developerConnection>
-        <tag>vaadin upload add-on for Vaadin 8</tag>
+        <url>git://github.com/mstahv/easyuploads.git</url>
+        <connection>scm:git:git://github.com/mstahv/easyuploads.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:/mstahv/easyuploads.git</developerConnection>
+        <tag>vaadin upload add-on</tag>
     </scm>
 
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/mstahv/easyuploads/issues</url>
+    </issueManagement>
 
     <licenses>
         <license>
@@ -358,14 +362,6 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
-<!--
-        <dependency>
-            <groupId>org.vaadin</groupId>
-            <artifactId>viritin</artifactId>
-            <version>1.53</version>
-            <type>jar</type>
-        </dependency>
--->
     </dependencies>
 
 </project>

--- a/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
@@ -29,6 +29,7 @@ import com.vaadin.server.StreamVariable.StreamingProgressEvent;
 import com.vaadin.server.StreamVariable.StreamingStartEvent;
 import com.vaadin.server.WebBrowser;
 import com.vaadin.shared.communication.PushMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.DragAndDropWrapper;
@@ -121,14 +122,16 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
         MultiUploadHandler handler = new MultiUploadHandler() {
             private LinkedList<ProgressBar> indicators;
 
-            public void streamingStarted(StreamingStartEvent event) {
+            @Override
+			public void streamingStarted(StreamingStartEvent event) {
                 if (maxFileSize > 0 && event.getContentLength() > maxFileSize) {
                     throw new MaxFileSizeExceededException(
                             event.getContentLength(), maxFileSize);
                 }
             }
 
-            public void streamingFinished(StreamingEndEvent event) {
+            @Override
+			public void streamingFinished(StreamingEndEvent event) {
                 if (!indicators.isEmpty()) {
                     getprogressBarsLayout()
                             .removeComponent(indicators.remove(0));
@@ -144,7 +147,8 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 resetPollIntervalIfNecessary();
             }
 
-            public void streamingFailed(StreamingErrorEvent event) {
+            @Override
+			public void streamingFailed(StreamingErrorEvent event) {
                 Logger.getLogger(getClass().getName()).log(Level.FINE,
                         "Streaming failed", event.getException());
 
@@ -155,21 +159,24 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 resetPollIntervalIfNecessary();
             }
 
-            public void onProgress(StreamingProgressEvent event) {
+            @Override
+			public void onProgress(StreamingProgressEvent event) {
                 long readBytes = event.getBytesReceived();
                 long contentLength = event.getContentLength();
                 float f = (float) readBytes / (float) contentLength;
                 indicators.get(0).setValue(f);
             }
 
-            public OutputStream getOutputStream() {
+            @Override
+			public OutputStream getOutputStream() {
                 FileDetail next = upload.getPendingFileNames().iterator()
                         .next();
                 return receiver.receiveUpload(next.getFileName(),
                         next.getMimeType());
             }
 
-            public void filesQueued(Collection<FileDetail> pendingFileNames) {
+            @Override
+			public void filesQueued(Collection<FileDetail> pendingFileNames) {
                 if (indicators == null) {
                     indicators = new LinkedList<ProgressBar>();
                 }
@@ -297,7 +304,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
      */
     protected void prepareDropZone() {
         if (dropZone == null) {
-            Component label = new Label(getAreaText(), Label.CONTENT_XHTML);
+            Component label = new Label(getAreaText(), ContentMode.HTML);
             label.setSizeUndefined();
             dropZone = new DragAndDropWrapper(label);
             dropZone.setStyleName("v-multifileupload-dropzone");
@@ -346,14 +353,16 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 new DirectoryFileFactory(new File(directoryWhereToUpload)));
     }
 
-    public AcceptCriterion getAcceptCriterion() {
+    @Override
+	public AcceptCriterion getAcceptCriterion() {
         // TODO accept only files
         // return new And(new TargetDetailIs("verticalLocation","MIDDLE"), new
         // TargetDetailIs("horizontalLoction", "MIDDLE"));
         return AcceptAll.get();
     }
 
-    public void drop(DragAndDropEvent event) {
+    @Override
+	public void drop(DragAndDropEvent event) {
         DragAndDropWrapper.WrapperTransferable transferable = (WrapperTransferable) event
                 .getTransferable();
         Html5File[] files = transferable.getFiles();
@@ -385,27 +394,32 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 private String name;
                 private String mime;
 
-                public OutputStream getOutputStream() {
+                @Override
+				public OutputStream getOutputStream() {
                     return receiver.receiveUpload(name, mime);
                 }
 
-                public boolean listenProgress() {
+                @Override
+				public boolean listenProgress() {
                     return true;
                 }
 
-                public void onProgress(StreamingProgressEvent event) {
+                @Override
+				public void onProgress(StreamingProgressEvent event) {
                     float p = (float) event.getBytesReceived()
                             / (float) event.getContentLength();
                     pi.setValue(p);
                 }
 
-                public void streamingStarted(StreamingStartEvent event) {
+                @Override
+				public void streamingStarted(StreamingStartEvent event) {
                     name = event.getFileName();
                     mime = event.getMimeType();
 
                 }
 
-                public void streamingFinished(StreamingEndEvent event) {
+                @Override
+				public void streamingFinished(StreamingEndEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     handleFile(receiver.getFile(), html5File.getFileName(),
                             html5File.getType(), html5File.getFileSize());
@@ -413,12 +427,14 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                     resetPollIntervalIfNecessary();
                 }
 
-                public void streamingFailed(StreamingErrorEvent event) {
+                @Override
+				public void streamingFailed(StreamingErrorEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     resetPollIntervalIfNecessary();
                 }
 
-                public boolean isInterrupted() {
+                @Override
+				public boolean isInterrupted() {
                     return false;
                 }
             });

--- a/src/main/java/org/vaadin/easyuploads/UploadField.java
+++ b/src/main/java/org/vaadin/easyuploads/UploadField.java
@@ -26,7 +26,6 @@ import com.vaadin.ui.Upload.ProgressListener;
 import com.vaadin.ui.Upload.Receiver;
 import com.vaadin.ui.Upload.StartedEvent;
 import com.vaadin.ui.Upload.StartedListener;
-import com.vaadin.v7.ui.ProgressIndicator;
 
 /**
  * UploadField is a helper class that uses rather low level {@link Upload}

--- a/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
+++ b/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
@@ -5,7 +5,6 @@
 
 	<inherits name="org.swfupload.SWFUpload" />
     <inherits name="com.vaadin.DefaultWidgetSet" />
-    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
 
 	<replace-with class="org.vaadin.easyuploads.client.ui.VSWFUpload">
 		<when-type-is class="org.vaadin.easyuploads.client.ui.VMultiUpload" />

--- a/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
+++ b/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
@@ -4,7 +4,8 @@
 	<!-- WS Compiler: manually edited -->
 
 	<inherits name="org.swfupload.SWFUpload" />
-	<inherits name="com.vaadin.terminal.gwt.DefaultWidgetSet" />
+    <inherits name="com.vaadin.DefaultWidgetSet" />
+    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
 
 	<replace-with class="org.vaadin.easyuploads.client.ui.VSWFUpload">
 		<when-type-is class="org.vaadin.easyuploads.client.ui.VMultiUpload" />

--- a/src/main/java/org/vaadin/easyuploads/client/ui/VMultiUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/client/ui/VMultiUpload.java
@@ -119,13 +119,15 @@ public class VMultiUpload extends SimplePanel
     private String receiverUri;
 
     private ReadyStateChangeHandler readyStateChangeHandler = new ReadyStateChangeHandler() {
-        public void onReadyStateChange(XMLHttpRequest xhr) {
+        @Override
+		public void onReadyStateChange(XMLHttpRequest xhr) {
             if (xhr.getReadyState() == XMLHttpRequest.DONE) {
                 xhr.clearOnReadyStateChange();
                 VConsole.log("Ready state + " + xhr.getReadyState());
 
                 Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-                    public void execute() {
+                    @Override
+					public void execute() {
                         if (isAttached() && !fileQueue.isEmpty()) {
                             client.updateVariable(paintableId, "ready", true,
                                     true);
@@ -144,7 +146,8 @@ public class VMultiUpload extends SimplePanel
         panel.add(fu);
         submitButton = new VButton();
         submitButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
+            @Override
+			public void onClick(ClickEvent event) {
                 // fire click on upload (eg. focused button and hit space)
                 fireNativeClick(fu.getElement());
             }
@@ -157,7 +160,8 @@ public class VMultiUpload extends SimplePanel
         addStyleName(CLASSNAME + "-immediate");
     }
 
-    public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
+    @Override
+	public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
         if (client.updateComponent(this, uidl, true)) {
             return;
         }
@@ -292,7 +296,7 @@ public class VMultiUpload extends SimplePanel
             } else if (!AcceptUtil.accepted(file.getName(), file.getType(),
                     accepted)) {
                 noMatches.add(file);
-            } else if (maxFileCount != null && filedetails.size() >= maxFileCount) {
+            } else if (maxFileCount != null && filedetails.size() > maxFileCount) {
                 tooMany.add(file);
             } else {
                 queueFilePost(file);

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/ClearTest.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/ClearTest.java
@@ -1,14 +1,12 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
-import com.vaadin.data.Property;
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.easyuploads.UploadField;
+
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.VerticalLayout;
-
-import org.vaadin.easyuploads.*;
-
-import org.vaadin.addonhelpers.AbstractTest;
 
 public class ClearTest extends AbstractTest {
 
@@ -19,22 +17,14 @@ public class ClearTest extends AbstractTest {
         uplDocument.setButtonCaption("...Select File");
         uplDocument.setDisplayUpload(false);
         
-        uplDocument.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                Notification.show("File uploaded" + uplDocument.getLastFileName() + " IsEmpty:" + uplDocument.isEmpty());
-            }
-        });
+        uplDocument.addValueChangeListener(event -> Notification.show("File uploaded" + uplDocument.getLastFileName() + " IsEmpty:" + uplDocument.isEmpty()));
         
         layout.addComponent(uplDocument);
         
         Button button = new Button("Test is clear + isEmtpy");
-        button.addClickListener(new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
-                uplDocument.clear();
-                Notification.show("IsEmpty: " + uplDocument.isEmpty());
-            }
+        button.addClickListener(event -> {
+            uplDocument.clear();
+            Notification.show("IsEmpty: " + uplDocument.isEmpty());
         });
         layout.addComponent(button);
         

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
@@ -1,32 +1,27 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
-import org.vaadin.easyuploads.ImagePreviewField;
-import com.vaadin.annotations.Theme;
-import java.io.*;
-import java.text.*;
-import java.util.*;
-
-import javax.imageio.*;
-
-import org.vaadin.easyuploads.*;
-import org.vaadin.easyuploads.UploadField.FieldType;
-
-import com.vaadin.server.*;
-import com.vaadin.ui.*;
-import com.vaadin.ui.themes.ValoTheme;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.commons.io.IOUtils;
 import org.vaadin.addonhelpers.AbstractTest;
-import org.vaadin.viritin.BeanBinder;
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.layouts.MHorizontalLayout;
-import org.vaadin.viritin.layouts.MVerticalLayout;
+import org.vaadin.easyuploads.ImagePreviewField;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.data.Binder;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.VerticalLayout;
 
 @Theme("valo")
 public class CustomDisplayTestWithPojo extends AbstractTest {
 
-    private MBeanFieldGroup<Pojo> bfg;
+    private Binder<Pojo> bfg;
 
     public static class Pojo {
 
@@ -57,7 +52,7 @@ public class CustomDisplayTestWithPojo extends AbstractTest {
 
     @Override
     public Component getTestComponent() {
-        VerticalLayout layout = new MVerticalLayout();
+        VerticalLayout layout = new VerticalLayout();
         photo.setCaption("Custom prview for images.");
 
         Button button = new Button("Show photo state");
@@ -78,33 +73,29 @@ public class CustomDisplayTestWithPojo extends AbstractTest {
         });
 
         Button load = new Button("Load photo");
-        load.addClickListener(new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
-                bfg.unbind();
-                InputStream resourceAsStream = getClass().getResourceAsStream("/boat.png");
-                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                try {
-                    IOUtils.copy(resourceAsStream, byteArrayOutputStream);
-                    pojo.setPhoto(byteArrayOutputStream.toByteArray());
-                    bfg = BeanBinder.bind(pojo, CustomDisplayTestWithPojo.this);
-                } catch (IOException ex) {
-                    Logger.getLogger(CustomDisplayTestWithPojo.class.getName()).log(Level.SEVERE, null, ex);
-                }
+        load.addClickListener(event -> {
+            bfg.removeBean();
+            InputStream resourceAsStream = getClass().getResourceAsStream("/boat.png");
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            try {
+                IOUtils.copy(resourceAsStream, byteArrayOutputStream);
+                pojo.setPhoto(byteArrayOutputStream.toByteArray());
+                bfg.setBean(pojo);
+            } catch (IOException ex) {
+                Logger.getLogger(CustomDisplayTestWithPojo.class.getName()).log(Level.SEVERE, null, ex);
             }
         });
 
-        Button clear = new Button("clear value", new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
+        Button clear = new Button("clear value", event -> {
                 pojo.setPhoto(null);
-                bfg = BeanBinder.bind(pojo, CustomDisplayTestWithPojo.this);
-            }
+                bfg.setBean(pojo);
         });
 
-        bfg = BeanBinder.bind(pojo, this);
+        bfg = new Binder<>();
+        bfg.bindInstanceFields(this);
+        bfg.setBean(pojo);
 
-        layout.addComponents(photo, new MHorizontalLayout( button, load, clear));
+        layout.addComponents(photo, new HorizontalLayout( button, load, clear));
         return layout;
     }
 

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/DisabledTest.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/DisabledTest.java
@@ -1,19 +1,17 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
+import java.io.File;
+
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.easyuploads.UploadField;
+
 import com.vaadin.annotations.Theme;
-import com.vaadin.data.Property;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Component;
-import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.Upload;
 import com.vaadin.ui.VerticalLayout;
-import java.io.File;
-
-import org.vaadin.easyuploads.*;
-
-import org.vaadin.addonhelpers.AbstractTest;
 
 @Theme("valo")
 public class DisabledTest extends AbstractTest {
@@ -48,12 +46,7 @@ public class DisabledTest extends AbstractTest {
         file.setButtonCaption("...Select File");
         file.setDisplayUpload(false);
 
-        file.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                Notification.show("File uploaded" + file.getLastFileName() + " IsEmpty:" + file.isEmpty());
-            }
-        });
+        file.addValueChangeListener(event -> Notification.show("File uploaded" + file.getLastFileName() + " IsEmpty:" + file.isEmpty()));
 
         layout.addComponent(file);
         
@@ -68,15 +61,12 @@ public class DisabledTest extends AbstractTest {
  
         CheckBox cb = new CheckBox("Enabled");
         cb.setValue(false);
-        cb.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                final boolean nextEnabled = !file.isEnabled();
-                file.setEnabled(nextEnabled);
-                wrap.setEnabled(nextEnabled);
-                boolean enabled = upload.isEnabled();
-                Notification.show("Enabled: " + enabled);
-            }
+        cb.addValueChangeListener(event -> {
+            final boolean nextEnabled = !file.isEnabled();
+            file.setEnabled(nextEnabled);
+            wrap.setEnabled(nextEnabled);
+            boolean enabled = upload.isEnabled();
+            Notification.show("Enabled: " + enabled);
         });
         
         layout.addComponents(wrap, cb);


### PR DESCRIPTION
You will want to review the POM changes - I think I only modified version #s (made it v8), and dependencies.

I removed the Viritin dependency, as it is a large library with multiple dependencies, and used only for string escaping, which is done differently/better now anyway in Vaadin.  Added Commons-IO explicitly (was a transitive dependency from Viritin) - it is only used for ```FileUtils.byteCountToDisplaySize(long)```.

I think the UI test server framework you referenced in your comment needs updating for Vaadin 8 - I couldn't get the Jetty instance to launch, complaining about a method not found.  I think the argument type changed packages in V8 or something.

This works for me in my project, drag/drop, clicking and selecting a file/files, displaying in-process uploads (using the newer progress component) etc.