### PR TITLE
Scrmtrey master v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>7.4.11-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -11,16 +11,12 @@
     </organization>
 
     <scm>
-        <url>git://github.com/mstahv/easyuploads.git</url>
-        <connection>scm:git:git://github.com/mstahv/easyuploads.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:/mstahv/easyuploads.git</developerConnection>
-        <tag>vaadin upload add-on</tag>
+        <url>git://github.com/WoozyG/easyuploads.git</url>
+        <connection>scm:git:git://github.com/WoozyG/easyuploads.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:/WoozyG/easyuploads.git</developerConnection>
+        <tag>vaadin upload add-on for Vaadin 8</tag>
     </scm>
 
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/mstahv/easyuploads/issues</url>
-    </issueManagement>
 
     <licenses>
         <license>
@@ -33,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.7.4</vaadin.version>
+        <vaadin.version>8.0.0</vaadin.version>
     </properties>
 
     <build>
@@ -47,8 +43,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
@@ -142,6 +138,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+							<extraJvmArgs>-Xmx1G</extraJvmArgs>
                             <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
@@ -294,6 +291,30 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-server</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-client</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        
+		<dependency>
+		    <groupId>commons-io</groupId>
+		    <artifactId>commons-io</artifactId>
+		    <version>2.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+		    <version>3.5</version>
+		</dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-themes</artifactId>
             <version>${vaadin.version}</version>
             <scope>test</scope>
@@ -337,12 +358,14 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+<!--
         <dependency>
             <groupId>org.vaadin</groupId>
             <artifactId>viritin</artifactId>
             <version>1.53</version>
             <type>jar</type>
         </dependency>
+-->
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -55,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -83,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -142,7 +143,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-							<extraJvmArgs>-Xmx1G</extraJvmArgs>
+                            <extraJvmArgs>-Xmx1G</extraJvmArgs>
                             <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
@@ -294,16 +295,16 @@
             <scope>provided</scope>
         </dependency>
         
-		<dependency>
-		    <groupId>commons-io</groupId>
-		    <artifactId>commons-io</artifactId>
-		    <version>2.5</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-lang3</artifactId>
-		    <version>3.5</version>
-		</dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
         
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -311,29 +312,22 @@
             <version>${vaadin.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>7.2.2.v20101205</version>
-            <scope>test</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.vaadin</groupId>
             <artifactId>addon-test-helpers</artifactId>
-            <version>1.2</version>
+            <version>2.0.alpha5</version>
             <scope>test</scope>
         </dependency>
 
         <!-- If you have testbench licence, use that instead of raw selenium. Much 
         more robust results -->
-        <dependency>
+<!--        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench</artifactId>
             <version>3.0.4</version>
             <scope>test</scope>
-        </dependency>
+        </dependency>-->
 
         <!-- Open source alternative to TestBench -->
         <!-- <dependency> -->
@@ -343,13 +337,6 @@
         <!-- <scope>test</scope> -->
         <!-- </dependency> -->
 
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.10</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>8.0.2-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>8.0.0</vaadin.version>
+        <vaadin.version>8.0.2</vaadin.version>
     </properties>
 
     <build>
@@ -290,18 +290,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-client</artifactId>
-            <version>${vaadin.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-compatibility-server</artifactId>
-            <version>${vaadin.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-compatibility-client</artifactId>
             <version>${vaadin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,16 @@
     </organization>
 
     <scm>
-        <url>git://github.com/WoozyG/easyuploads.git</url>
-        <connection>scm:git:git://github.com/WoozyG/easyuploads.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:/WoozyG/easyuploads.git</developerConnection>
-        <tag>vaadin upload add-on for Vaadin 8</tag>
+        <url>git://github.com/mstahv/easyuploads.git</url>
+        <connection>scm:git:git://github.com/mstahv/easyuploads.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:/mstahv/easyuploads.git</developerConnection>
+        <tag>vaadin upload add-on</tag>
     </scm>
 
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/mstahv/easyuploads/issues</url>
+    </issueManagement>
 
     <licenses>
         <license>
@@ -358,14 +362,6 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
-<!--
-        <dependency>
-            <groupId>org.vaadin</groupId>
-            <artifactId>viritin</artifactId>
-            <version>1.53</version>
-            <type>jar</type>
-        </dependency>
--->
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>8.0.2-SNAPSHOT</version>
+    <version>8.0.3-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>8.0.2</vaadin.version>
+        <vaadin.version>8.1.0</vaadin.version>
     </properties>
 
     <build>

--- a/src/main/java/org/vaadin/easyuploads/FileBuffer.java
+++ b/src/main/java/org/vaadin/easyuploads/FileBuffer.java
@@ -50,17 +50,17 @@ public abstract class FileBuffer implements UploadFieldReceiver {
 
     /**
      * Helper method for UploadField.
-     * 
+     *
      * @see org.vaadin.easyuploads.UploadFieldReceiver#getValue()
      */
-    public Object getValue() {
+    public byte[] getValue() {
         if (file == null || !file.exists()) {
             return null;
         }
 
-        if (getFieldType() == FieldType.FILE) {
-            return file;
-        }
+//        if (getFieldType() == FieldType.FILE) {
+//            return file;
+//        }
 
         InputStream valueAsStream = getContentAsStream();
 
@@ -72,7 +72,7 @@ public abstract class FileBuffer implements UploadFieldReceiver {
             if (getFieldType() == FieldType.BYTE_ARRAY) {
                 return byteArray;
             } else {
-                return new String(byteArray);
+                return null;
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/vaadin/easyuploads/ImagePreviewField.java
+++ b/src/main/java/org/vaadin/easyuploads/ImagePreviewField.java
@@ -32,7 +32,7 @@ import javax.imageio.ImageIO;
  * A simple field to edit images stored as byte arrays (e.g. in database).
  */
 public class ImagePreviewField extends UploadField {
-    
+
     public ImagePreviewField() {
         setAcceptFilter("image/*");
         setFieldType(FieldType.BYTE_ARRAY);
@@ -51,12 +51,12 @@ public class ImagePreviewField extends UploadField {
         try {
             Image image = (Image) display;
             // check if upload is an image
-            if (ImageIO.read(new ByteArrayInputStream((byte[]) getValue())) != null) {
+            if (ImageIO.read(new ByteArrayInputStream(getValue())) != null) {
                 // Update the image according to
                 // https://vaadin.com/book/vaadin7/-/page/components.embedded.html
                 SimpleDateFormat df = new SimpleDateFormat("yyyyMMddHHmmssSSS");
                 String filename = df.format(new Date()) + getLastFileName();
-                StreamResource resource = new StreamResource(new ImageSource((byte[]) getValue()), filename);
+                StreamResource resource = new StreamResource(new ImageSource(getValue()), filename);
                 resource.setCacheTime(0);
                 image.setSource(resource);
             } else {
@@ -98,5 +98,5 @@ public class ImagePreviewField extends UploadField {
             return new ByteArrayInputStream(buffer);
         }
     }
-    
+
 }

--- a/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
@@ -14,6 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.vaadin.easyuploads.MultiUpload.FileDetail;
 import org.vaadin.easyuploads.UploadField.FieldType;
 import org.vaadin.easyuploads.client.AcceptUtil;
@@ -123,7 +124,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             private LinkedList<ProgressBar> indicators;
 
             @Override
-			public void streamingStarted(StreamingStartEvent event) {
+            public void streamingStarted(StreamingStartEvent event) {
                 if (maxFileSize > 0 && event.getContentLength() > maxFileSize) {
                     throw new MaxFileSizeExceededException(
                             event.getContentLength(), maxFileSize);
@@ -131,7 +132,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
-			public void streamingFinished(StreamingEndEvent event) {
+            public void streamingFinished(StreamingEndEvent event) {
                 if (!indicators.isEmpty()) {
                     getprogressBarsLayout()
                             .removeComponent(indicators.remove(0));
@@ -148,7 +149,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
-			public void streamingFailed(StreamingErrorEvent event) {
+            public void streamingFailed(StreamingErrorEvent event) {
                 Logger.getLogger(getClass().getName()).log(Level.FINE,
                         "Streaming failed", event.getException());
 
@@ -160,7 +161,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
-			public void onProgress(StreamingProgressEvent event) {
+            public void onProgress(StreamingProgressEvent event) {
                 long readBytes = event.getBytesReceived();
                 long contentLength = event.getContentLength();
                 float f = (float) readBytes / (float) contentLength;
@@ -168,7 +169,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
-			public OutputStream getOutputStream() {
+            public OutputStream getOutputStream() {
                 FileDetail next = upload.getPendingFileNames().iterator()
                         .next();
                 return receiver.receiveUpload(next.getFileName(),
@@ -176,7 +177,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
-			public void filesQueued(Collection<FileDetail> pendingFileNames) {
+            public void filesQueued(Collection<FileDetail> pendingFileNames) {
                 if (indicators == null) {
                     indicators = new LinkedList<ProgressBar>();
                 }
@@ -273,6 +274,12 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
 
             @Override
+            public void setValue(byte[] newValue) {
+                //TODO: complete setValue when you want to use MultiFileUpload
+                throw new NotImplementedException("Not implemented, TODO");
+            }
+
+            @Override
             public void setLastMimeType(String mimeType) {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
@@ -339,7 +346,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
     }
 
     abstract protected void handleFile(File file, String fileName,
-            String mimeType, long length);
+                                       String mimeType, long length);
 
     /**
      * A helper method to set DirectoryFileFactory with given pathname as
@@ -354,7 +361,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
     }
 
     @Override
-	public AcceptCriterion getAcceptCriterion() {
+    public AcceptCriterion getAcceptCriterion() {
         // TODO accept only files
         // return new And(new TargetDetailIs("verticalLocation","MIDDLE"), new
         // TargetDetailIs("horizontalLoction", "MIDDLE"));
@@ -362,7 +369,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
     }
 
     @Override
-	public void drop(DragAndDropEvent event) {
+    public void drop(DragAndDropEvent event) {
         DragAndDropWrapper.WrapperTransferable transferable = (WrapperTransferable) event
                 .getTransferable();
         Html5File[] files = transferable.getFiles();
@@ -395,31 +402,31 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 private String mime;
 
                 @Override
-				public OutputStream getOutputStream() {
+                public OutputStream getOutputStream() {
                     return receiver.receiveUpload(name, mime);
                 }
 
                 @Override
-				public boolean listenProgress() {
+                public boolean listenProgress() {
                     return true;
                 }
 
                 @Override
-				public void onProgress(StreamingProgressEvent event) {
+                public void onProgress(StreamingProgressEvent event) {
                     float p = (float) event.getBytesReceived()
                             / (float) event.getContentLength();
                     pi.setValue(p);
                 }
 
                 @Override
-				public void streamingStarted(StreamingStartEvent event) {
+                public void streamingStarted(StreamingStartEvent event) {
                     name = event.getFileName();
                     mime = event.getMimeType();
 
                 }
 
                 @Override
-				public void streamingFinished(StreamingEndEvent event) {
+                public void streamingFinished(StreamingEndEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     handleFile(receiver.getFile(), html5File.getFileName(),
                             html5File.getType(), html5File.getFileSize());
@@ -428,13 +435,13 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 }
 
                 @Override
-				public void streamingFailed(StreamingErrorEvent event) {
+                public void streamingFailed(StreamingErrorEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     resetPollIntervalIfNecessary();
                 }
 
                 @Override
-				public boolean isInterrupted() {
+                public boolean isInterrupted() {
                     return false;
                 }
             });
@@ -529,7 +536,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
             }
         }
     }
-    
+
     public void setMaxFileCount(int maxFileCount) {
         this.maxFileCount = maxFileCount;
         int uploadCount = html5FileInputSettings.entrySet().size();

--- a/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/MultiFileUpload.java
@@ -29,6 +29,7 @@ import com.vaadin.server.StreamVariable.StreamingProgressEvent;
 import com.vaadin.server.StreamVariable.StreamingStartEvent;
 import com.vaadin.server.WebBrowser;
 import com.vaadin.shared.communication.PushMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.DragAndDropWrapper;
@@ -121,14 +122,16 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
         MultiUploadHandler handler = new MultiUploadHandler() {
             private LinkedList<ProgressBar> indicators;
 
-            public void streamingStarted(StreamingStartEvent event) {
+            @Override
+			public void streamingStarted(StreamingStartEvent event) {
                 if (maxFileSize > 0 && event.getContentLength() > maxFileSize) {
                     throw new MaxFileSizeExceededException(
                             event.getContentLength(), maxFileSize);
                 }
             }
 
-            public void streamingFinished(StreamingEndEvent event) {
+            @Override
+			public void streamingFinished(StreamingEndEvent event) {
                 if (!indicators.isEmpty()) {
                     getprogressBarsLayout()
                             .removeComponent(indicators.remove(0));
@@ -144,7 +147,8 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 resetPollIntervalIfNecessary();
             }
 
-            public void streamingFailed(StreamingErrorEvent event) {
+            @Override
+			public void streamingFailed(StreamingErrorEvent event) {
                 Logger.getLogger(getClass().getName()).log(Level.FINE,
                         "Streaming failed", event.getException());
 
@@ -155,21 +159,24 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 resetPollIntervalIfNecessary();
             }
 
-            public void onProgress(StreamingProgressEvent event) {
+            @Override
+			public void onProgress(StreamingProgressEvent event) {
                 long readBytes = event.getBytesReceived();
                 long contentLength = event.getContentLength();
                 float f = (float) readBytes / (float) contentLength;
                 indicators.get(0).setValue(f);
             }
 
-            public OutputStream getOutputStream() {
+            @Override
+			public OutputStream getOutputStream() {
                 FileDetail next = upload.getPendingFileNames().iterator()
                         .next();
                 return receiver.receiveUpload(next.getFileName(),
                         next.getMimeType());
             }
 
-            public void filesQueued(Collection<FileDetail> pendingFileNames) {
+            @Override
+			public void filesQueued(Collection<FileDetail> pendingFileNames) {
                 if (indicators == null) {
                     indicators = new LinkedList<ProgressBar>();
                 }
@@ -297,7 +304,7 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
      */
     protected void prepareDropZone() {
         if (dropZone == null) {
-            Component label = new Label(getAreaText(), Label.CONTENT_XHTML);
+            Component label = new Label(getAreaText(), ContentMode.HTML);
             label.setSizeUndefined();
             dropZone = new DragAndDropWrapper(label);
             dropZone.setStyleName("v-multifileupload-dropzone");
@@ -346,14 +353,16 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 new DirectoryFileFactory(new File(directoryWhereToUpload)));
     }
 
-    public AcceptCriterion getAcceptCriterion() {
+    @Override
+	public AcceptCriterion getAcceptCriterion() {
         // TODO accept only files
         // return new And(new TargetDetailIs("verticalLocation","MIDDLE"), new
         // TargetDetailIs("horizontalLoction", "MIDDLE"));
         return AcceptAll.get();
     }
 
-    public void drop(DragAndDropEvent event) {
+    @Override
+	public void drop(DragAndDropEvent event) {
         DragAndDropWrapper.WrapperTransferable transferable = (WrapperTransferable) event
                 .getTransferable();
         Html5File[] files = transferable.getFiles();
@@ -385,27 +394,32 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                 private String name;
                 private String mime;
 
-                public OutputStream getOutputStream() {
+                @Override
+				public OutputStream getOutputStream() {
                     return receiver.receiveUpload(name, mime);
                 }
 
-                public boolean listenProgress() {
+                @Override
+				public boolean listenProgress() {
                     return true;
                 }
 
-                public void onProgress(StreamingProgressEvent event) {
+                @Override
+				public void onProgress(StreamingProgressEvent event) {
                     float p = (float) event.getBytesReceived()
                             / (float) event.getContentLength();
                     pi.setValue(p);
                 }
 
-                public void streamingStarted(StreamingStartEvent event) {
+                @Override
+				public void streamingStarted(StreamingStartEvent event) {
                     name = event.getFileName();
                     mime = event.getMimeType();
 
                 }
 
-                public void streamingFinished(StreamingEndEvent event) {
+                @Override
+				public void streamingFinished(StreamingEndEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     handleFile(receiver.getFile(), html5File.getFileName(),
                             html5File.getType(), html5File.getFileSize());
@@ -413,12 +427,14 @@ public abstract class MultiFileUpload extends CssLayout implements DropHandler {
                     resetPollIntervalIfNecessary();
                 }
 
-                public void streamingFailed(StreamingErrorEvent event) {
+                @Override
+				public void streamingFailed(StreamingErrorEvent event) {
                     getprogressBarsLayout().removeComponent(pi);
                     resetPollIntervalIfNecessary();
                 }
 
-                public boolean isInterrupted() {
+                @Override
+				public boolean isInterrupted() {
                     return false;
                 }
             });

--- a/src/main/java/org/vaadin/easyuploads/MultiUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/MultiUpload.java
@@ -21,9 +21,9 @@ import com.vaadin.ui.LegacyComponent;
 public class MultiUpload extends AbstractComponent implements LegacyComponent {
 
 	List<FileDetail> pendingFiles = new ArrayList<FileDetail>();
-        List<FinishedListener> finishedListeners = new ArrayList<FinishedListener>();
+	List<FinishedListener> finishedListeners = new ArrayList<FinishedListener>();
 
-        private String buttonCaption = "...";
+	private String buttonCaption = "...";
 	private MultiUploadHandler receiver;
 
 	StreamVariable streamVariable = new StreamVariable() {
@@ -77,11 +77,11 @@ public class MultiUpload extends AbstractComponent implements LegacyComponent {
 					return event.getBytesReceived();
 				}
 
-                        });
-                        for (FinishedListener finishedListener : finishedListeners) {
-                            finishedListener.uploadFinished();
-                        }
-                }
+			});
+			for (FinishedListener finishedListener : finishedListeners) {
+				finishedListener.uploadFinished();
+			}
+		}
 
 		public void streamingFailed(StreamingErrorEvent event) {
 			receiver.streamingFailed(event);
@@ -159,7 +159,7 @@ public class MultiUpload extends AbstractComponent implements LegacyComponent {
 			String[] split = data.split("---xXx---");
 			caption = split[1];
 			contentLength = Long.parseLong(split[0]);
-      if (split.length >= 3) {
+			if (split.length >= 3) {
 				mimeType = split[2];
 			}
 		}
@@ -177,14 +177,14 @@ public class MultiUpload extends AbstractComponent implements LegacyComponent {
 		}
 	}
 
-        public void addFinishedListener(FinishedListener finishedListener) {
-            if (!finishedListeners.contains(finishedListener)) {
-                finishedListeners.add(finishedListener);
-            }
-        }
+	public void addFinishedListener(FinishedListener finishedListener) {
+		if (!finishedListeners.contains(finishedListener)) {
+			finishedListeners.add(finishedListener);
+		}
+	}
 
-        public interface FinishedListener {
-            void uploadFinished();
-        }
+	public interface FinishedListener {
+		void uploadFinished();
+	}
 
 }

--- a/src/main/java/org/vaadin/easyuploads/UploadField.java
+++ b/src/main/java/org/vaadin/easyuploads/UploadField.java
@@ -26,7 +26,6 @@ import com.vaadin.ui.Upload.ProgressListener;
 import com.vaadin.ui.Upload.Receiver;
 import com.vaadin.ui.Upload.StartedEvent;
 import com.vaadin.ui.Upload.StartedListener;
-import com.vaadin.v7.ui.ProgressIndicator;
 
 /**
  * UploadField is a helper class that uses rather low level {@link Upload}

--- a/src/main/java/org/vaadin/easyuploads/UploadFieldReceiver.java
+++ b/src/main/java/org/vaadin/easyuploads/UploadFieldReceiver.java
@@ -5,21 +5,22 @@ import java.io.InputStream;
 import com.vaadin.ui.Upload.Receiver;
 
 interface UploadFieldReceiver extends Receiver {
-	Object getValue();
+
+	byte[] getValue();
 
 	InputStream getContentAsStream();
 
-	void setValue(Object newValue);
+	void setValue(byte[] newValue);
 
 	boolean isEmpty();
 
 	long getLastFileSize();
 
 	String getLastMimeType();
-        
-        void setLastMimeType(String mimeType);
+
+	void setLastMimeType(String mimeType);
 
 	String getLastFileName();
-        
-        void setLastFileName(String fileName);
+
+	void setLastFileName(String fileName);
 }

--- a/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
+++ b/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
@@ -5,7 +5,6 @@
 
 	<inherits name="org.swfupload.SWFUpload" />
     <inherits name="com.vaadin.DefaultWidgetSet" />
-    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
 
 	<replace-with class="org.vaadin.easyuploads.client.ui.VSWFUpload">
 		<when-type-is class="org.vaadin.easyuploads.client.ui.VMultiUpload" />

--- a/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
+++ b/src/main/java/org/vaadin/easyuploads/Widgetset.gwt.xml
@@ -4,7 +4,8 @@
 	<!-- WS Compiler: manually edited -->
 
 	<inherits name="org.swfupload.SWFUpload" />
-	<inherits name="com.vaadin.terminal.gwt.DefaultWidgetSet" />
+    <inherits name="com.vaadin.DefaultWidgetSet" />
+    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
 
 	<replace-with class="org.vaadin.easyuploads.client.ui.VSWFUpload">
 		<when-type-is class="org.vaadin.easyuploads.client.ui.VMultiUpload" />

--- a/src/main/java/org/vaadin/easyuploads/client/ui/VMultiUpload.java
+++ b/src/main/java/org/vaadin/easyuploads/client/ui/VMultiUpload.java
@@ -119,13 +119,15 @@ public class VMultiUpload extends SimplePanel
     private String receiverUri;
 
     private ReadyStateChangeHandler readyStateChangeHandler = new ReadyStateChangeHandler() {
-        public void onReadyStateChange(XMLHttpRequest xhr) {
+        @Override
+		public void onReadyStateChange(XMLHttpRequest xhr) {
             if (xhr.getReadyState() == XMLHttpRequest.DONE) {
                 xhr.clearOnReadyStateChange();
                 VConsole.log("Ready state + " + xhr.getReadyState());
 
                 Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-                    public void execute() {
+                    @Override
+					public void execute() {
                         if (isAttached() && !fileQueue.isEmpty()) {
                             client.updateVariable(paintableId, "ready", true,
                                     true);
@@ -144,7 +146,8 @@ public class VMultiUpload extends SimplePanel
         panel.add(fu);
         submitButton = new VButton();
         submitButton.addClickHandler(new ClickHandler() {
-            public void onClick(ClickEvent event) {
+            @Override
+			public void onClick(ClickEvent event) {
                 // fire click on upload (eg. focused button and hit space)
                 fireNativeClick(fu.getElement());
             }
@@ -157,7 +160,8 @@ public class VMultiUpload extends SimplePanel
         addStyleName(CLASSNAME + "-immediate");
     }
 
-    public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
+    @Override
+	public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
         if (client.updateComponent(this, uidl, true)) {
             return;
         }
@@ -292,7 +296,7 @@ public class VMultiUpload extends SimplePanel
             } else if (!AcceptUtil.accepted(file.getName(), file.getType(),
                     accepted)) {
                 noMatches.add(file);
-            } else if (maxFileCount != null && filedetails.size() >= maxFileCount) {
+            } else if (maxFileCount != null && filedetails.size() > maxFileCount) {
                 tooMany.add(file);
             } else {
                 queueFilePost(file);

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/BasicTest.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/BasicTest.java
@@ -35,7 +35,7 @@ import com.vaadin.ui.VerticalLayout;
 
 @Theme("valo")
 public class BasicTest extends AbstractTest {
-    
+
     @SuppressWarnings("serial")
     @Override
     public Component getTestComponent() {
@@ -43,11 +43,11 @@ public class BasicTest extends AbstractTest {
         final UploadField uploadField = new UploadField();
         uploadField.setCaption("Default mode: temp files, fieldType:"
                 + uploadField.getFieldType());
-        
+
         Button b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadField.getValue();
                 Notification.show("Value:" + value);
             }
@@ -55,16 +55,16 @@ public class BasicTest extends AbstractTest {
         mainWindow.addComponent(uploadField);
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         final UploadField uploadField2 = new UploadField();
         uploadField2.setFieldType(FieldType.FILE);
         uploadField2.setCaption("Storagemode: temp files, fieldType:"
                 + uploadField2.getFieldType());
-        
+
         b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadField2.getValue();
                 Notification.show("Value:" + value);
             }
@@ -72,40 +72,40 @@ public class BasicTest extends AbstractTest {
         mainWindow.addComponent(uploadField2);
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         final UploadField uploadField3 = new UploadField();
         uploadField3.setFieldType(FieldType.FILE);
         final File tempDir = Files.createTempDir();
         uploadField3.setCaption("Storagemode: " + tempDir + " , fieldType:"
                 + uploadField3.getFieldType());
-        
+
         uploadField3.setFileFactory(new FileFactory() {
             @Override
-			public File createFile(String fileName, String mimeType) {
+            public File createFile(String fileName, String mimeType) {
                 File f = new File(tempDir, fileName);
                 return f;
             }
         });
-        
+
         final UploadField uploadFieldHtml5Configured = new UploadField();
         uploadFieldHtml5Configured.setFieldType(FieldType.FILE);
         uploadFieldHtml5Configured.setCaption("Storagemode: " + tempDir + " , fieldType:"
                 + uploadFieldHtml5Configured.getFieldType() + " just images, max 1000000");
         uploadFieldHtml5Configured.setAcceptFilter("image/*");
         uploadFieldHtml5Configured.setMaxFileSize(1000000);
-        
+
         uploadFieldHtml5Configured.setFileFactory(new FileFactory() {
             @Override
-			public File createFile(String fileName, String mimeType) {
+            public File createFile(String fileName, String mimeType) {
                 File f = new File(tempDir, fileName);
                 return f;
             }
         });
-        
+
         b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadFieldHtml5Configured.getValue();
                 Notification.show("Value:" + value);
             }
@@ -113,14 +113,14 @@ public class BasicTest extends AbstractTest {
         mainWindow.addComponent(uploadFieldHtml5Configured);
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         final UploadField uploadField4 = new UploadField();
         uploadField4.setStorageMode(StorageMode.MEMORY);
         uploadField4.setFieldType(FieldType.UTF8_STRING);
         uploadField4
                 .setCaption("writethrough=false, Storagemode: memory , fieldType:"
                         + uploadField4.getFieldType());
-        
+
         mainWindow.addComponent(uploadField4);
         uploadField4.addValueChangeListener(new ValueChangeListener() {
             @Override
@@ -131,7 +131,7 @@ public class BasicTest extends AbstractTest {
         b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadField4.getValue();
                 Notification.show("Value:" + value);
             }
@@ -140,7 +140,7 @@ public class BasicTest extends AbstractTest {
         b = new Button("Discard");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 uploadField4.clear();
                 Object value = uploadField4.getValue();
                 Notification.show("Value:" + value);
@@ -148,28 +148,28 @@ public class BasicTest extends AbstractTest {
         });
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         final UploadField uploadField5 = new UploadField();
         uploadField5.setFieldType(FieldType.BYTE_ARRAY);
         uploadField5.setCaption("Storagemode: memory , fieldType:"
                 + uploadField5.getFieldType());
-        
+
         uploadField5.addValueChangeListener(new ValueChangeListener() {
             @Override
             public void valueChange(ValueChangeEvent event) {
-                
+
                 String lastFileName = uploadField5.getLastFileName();
                 String lastMimeType = uploadField5.getLastMimeType();
-                
+
                 Notification.show(lastFileName +  " " + lastMimeType);
-                
+
             }
         });
-        
+
         b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadField5.getValue();
                 Notification.show("Value:" + value);
             }
@@ -177,7 +177,7 @@ public class BasicTest extends AbstractTest {
         mainWindow.addComponent(uploadField5);
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         final UploadField uploadField6 = new UploadField() {
             @Override
             protected void updateDisplay() {
@@ -188,11 +188,11 @@ public class BasicTest extends AbstractTest {
                 if (mimeType.equals("image/png")) {
                     Resource resource = new StreamResource(
                             new StreamResource.StreamSource() {
-                        @Override
-						public InputStream getStream() {
-                            return new ByteArrayInputStream(pngData);
-                        }
-                    }, "") {
+                                @Override
+                                public InputStream getStream() {
+                                    return new ByteArrayInputStream(pngData);
+                                }
+                            }, "") {
                         @Override
                         public String getMIMEType() {
                             return "image/png";
@@ -211,11 +211,11 @@ public class BasicTest extends AbstractTest {
                 .setCaption("Storagemode: memory , fieldType:"
                         + uploadField6.getFieldType()
                         + ", overridden methods to display possibly loaded PNG in preview.");
-        
+
         b = new Button("Show value");
         b.addClickListener(new Button.ClickListener() {
             @Override
-			public void buttonClick(ClickEvent event) {
+            public void buttonClick(ClickEvent event) {
                 Object value = uploadField6.getValue();
                 Notification.show("Value:" + value);
             }
@@ -223,11 +223,11 @@ public class BasicTest extends AbstractTest {
         mainWindow.addComponent(uploadField6);
         mainWindow.addComponent(b);
         mainWindow.addComponent(hr());
-        
+
         MultiFileUpload multiFileUpload = new MultiFileUpload() {
             @Override
             protected void handleFile(File file, String fileName,
-                    String mimeType, long length) {
+                                      String mimeType, long length) {
                 String msg = fileName + " uploaded. Saved to temp file "
                         + file.getAbsolutePath() + " (size " + length
                         + " bytes)";
@@ -237,11 +237,11 @@ public class BasicTest extends AbstractTest {
         multiFileUpload.setCaption("MultiFileUpload");
         mainWindow.addComponent(multiFileUpload);
         mainWindow.addComponent(hr());
-        
+
         MultiFileUpload multiFileUploadLimited = new MultiFileUpload() {
             @Override
             protected void handleFile(File file, String fileName,
-                    String mimeType, long length) {
+                                      String mimeType, long length) {
                 String msg = fileName + " uploaded. Saved to temp file "
                         + file.getAbsolutePath() + " (size " + length
                         + " bytes)";
@@ -255,18 +255,18 @@ public class BasicTest extends AbstractTest {
         multiFileUploadLimited.setMaxFileCount(5);
         mainWindow.addComponent(multiFileUploadLimited);
         mainWindow.addComponent(hr());
-        
+
         MultiFileUpload multiFileUpload2 = new MultiFileUpload() {
             @Override
             protected void handleFile(File file, String fileName,
-                    String mimeType, long length) {
+                                      String mimeType, long length) {
                 String msg = fileName + " uploaded. Saved to file "
                         + file.getAbsolutePath() + " (size " + length
                         + " bytes)";
-                
+
                 Notification.show(msg);
             }
-            
+
             @Override
             protected FileBuffer createReceiver() {
                 FileBuffer receiver = super.createReceiver();
@@ -281,13 +281,13 @@ public class BasicTest extends AbstractTest {
         multiFileUpload2.setCaption("MultiFileUpload (with root dir)");
         multiFileUpload2.setRootDirectory(Files.createTempDir().toString());
         mainWindow.addComponent(multiFileUpload2);
-        
+
         mainWindow.addComponent(hr());
         MultiFileUpload multiFileUpload3 = new SlowMultiFileUpload();
         multiFileUpload3.setCaption("MultiFileUpload (simulated slow network)");
         multiFileUpload3.setUploadButtonCaption("Choose File(s)");
         mainWindow.addComponent(multiFileUpload3);
-        
+
         FormLayout maxSizeMultiUploadLayout = new FormLayout();
         maxSizeMultiUploadLayout.setCaption("MultiFileUpload with maxSize");
         mainWindow.addComponent(maxSizeMultiUploadLayout);
@@ -302,43 +302,43 @@ public class BasicTest extends AbstractTest {
                 Notification.show(msg);
             }
         };
-        
+
         final Binder<Integer[]> binder = new Binder<>();
         final Integer[] maxSize = new Integer[1];
         binder.forField(maxSizeField)
-        .withConverter(new StringToIntegerConverter("Invalid int"))
-        .bind((o) -> maxSize[0], (o, i) -> maxSize[0] = i);
+                .withConverter(new StringToIntegerConverter("Invalid int"))
+                .bind((o) -> maxSize[0], (o, i) -> maxSize[0] = i);
         binder.addValueChangeListener(event -> {
-                if (maxSizeField.getValue() != null) {
-                    multiFileUploadWithMaxSize.setMaxFileSize((Integer) event.getValue());
-                } else {
-                    multiFileUploadWithMaxSize.setMaxFileSize(0);
+                    if (maxSizeField.getValue() != null) {
+                        multiFileUploadWithMaxSize.setMaxFileSize((Integer) event.getValue());
+                    } else {
+                        multiFileUploadWithMaxSize.setMaxFileSize(0);
+                    }
                 }
-            }
         );
         maxSizeField.setValue("1048576");
-        
+
         maxSizeMultiUploadLayout.addComponent(multiFileUploadWithMaxSize);
         mainWindow.addComponent(hr());
-        
+
         return mainWindow;
     }
-    
+
     @Override
     protected void setup() {
         super.setup();
         content.setSizeUndefined();
     }
-    
+
     class SlowMultiFileUpload extends MultiFileUpload {
 
         @Override
         protected void handleFile(File file, String fileName, String mimeType,
-                long length) {
+                                  long length) {
             String msg = fileName + " uploaded.";
             Notification.show(msg);
         }
-        
+
         @Override
         protected FileBuffer createReceiver() {
             return new FileBuffer() {
@@ -346,16 +346,16 @@ public class BasicTest extends AbstractTest {
                 public FileFactory getFileFactory() {
                     return SlowMultiFileUpload.this.getFileFactory();
                 }
-                
+
                 @Override
                 public OutputStream receiveUpload(String filename,
-                        String MIMEType) {
+                                                  String MIMEType) {
                     final OutputStream receiveUpload = super.receiveUpload(
                             filename, MIMEType);
                     OutputStream slow = new OutputStream() {
                         private int slept;
                         private int written;
-                        
+
                         @Override
                         public void write(int b) throws IOException {
                             receiveUpload.write(b);
@@ -376,6 +376,11 @@ public class BasicTest extends AbstractTest {
                 }
 
                 @Override
+                public void setValue(byte[] newValue) {
+
+                }
+
+                @Override
                 public void setLastMimeType(String mimeType) {
                     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
                 }
@@ -384,15 +389,15 @@ public class BasicTest extends AbstractTest {
                 public void setLastFileName(String fileName) {
                     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
                 }
-                
+
             };
         }
-        
+
     }
-    
+
     private Component hr() {
         Label label = new Label("<hr>", ContentMode.HTML);
         return label;
     }
-    
+
 }

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/ClearTest.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/ClearTest.java
@@ -1,14 +1,12 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
-import com.vaadin.data.Property;
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.easyuploads.UploadField;
+
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.VerticalLayout;
-
-import org.vaadin.easyuploads.*;
-
-import org.vaadin.addonhelpers.AbstractTest;
 
 public class ClearTest extends AbstractTest {
 
@@ -19,22 +17,14 @@ public class ClearTest extends AbstractTest {
         uplDocument.setButtonCaption("...Select File");
         uplDocument.setDisplayUpload(false);
         
-        uplDocument.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                Notification.show("File uploaded" + uplDocument.getLastFileName() + " IsEmpty:" + uplDocument.isEmpty());
-            }
-        });
+        uplDocument.addValueChangeListener(event -> Notification.show("File uploaded" + uplDocument.getLastFileName() + " IsEmpty:" + uplDocument.isEmpty()));
         
         layout.addComponent(uplDocument);
         
         Button button = new Button("Test is clear + isEmtpy");
-        button.addClickListener(new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
-                uplDocument.clear();
-                Notification.show("IsEmpty: " + uplDocument.isEmpty());
-            }
+        button.addClickListener(event -> {
+            uplDocument.clear();
+            Notification.show("IsEmpty: " + uplDocument.isEmpty());
         });
         layout.addComponent(button);
         

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
@@ -1,32 +1,27 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
-import org.vaadin.easyuploads.ImagePreviewField;
-import com.vaadin.annotations.Theme;
-import java.io.*;
-import java.text.*;
-import java.util.*;
-
-import javax.imageio.*;
-
-import org.vaadin.easyuploads.*;
-import org.vaadin.easyuploads.UploadField.FieldType;
-
-import com.vaadin.server.*;
-import com.vaadin.ui.*;
-import com.vaadin.ui.themes.ValoTheme;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.commons.io.IOUtils;
 import org.vaadin.addonhelpers.AbstractTest;
-import org.vaadin.viritin.BeanBinder;
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.layouts.MHorizontalLayout;
-import org.vaadin.viritin.layouts.MVerticalLayout;
+import org.vaadin.easyuploads.ImagePreviewField;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.data.Binder;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.VerticalLayout;
 
 @Theme("valo")
 public class CustomDisplayTestWithPojo extends AbstractTest {
 
-    private MBeanFieldGroup<Pojo> bfg;
+    private Binder<Pojo> bfg;
 
     public static class Pojo {
 
@@ -57,7 +52,7 @@ public class CustomDisplayTestWithPojo extends AbstractTest {
 
     @Override
     public Component getTestComponent() {
-        VerticalLayout layout = new MVerticalLayout();
+        VerticalLayout layout = new VerticalLayout();
         photo.setCaption("Custom prview for images.");
 
         Button button = new Button("Show photo state");
@@ -78,33 +73,29 @@ public class CustomDisplayTestWithPojo extends AbstractTest {
         });
 
         Button load = new Button("Load photo");
-        load.addClickListener(new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
-                bfg.unbind();
-                InputStream resourceAsStream = getClass().getResourceAsStream("/boat.png");
-                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                try {
-                    IOUtils.copy(resourceAsStream, byteArrayOutputStream);
-                    pojo.setPhoto(byteArrayOutputStream.toByteArray());
-                    bfg = BeanBinder.bind(pojo, CustomDisplayTestWithPojo.this);
-                } catch (IOException ex) {
-                    Logger.getLogger(CustomDisplayTestWithPojo.class.getName()).log(Level.SEVERE, null, ex);
-                }
+        load.addClickListener(event -> {
+            bfg.removeBean();
+            InputStream resourceAsStream = getClass().getResourceAsStream("/boat.png");
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            try {
+                IOUtils.copy(resourceAsStream, byteArrayOutputStream);
+                pojo.setPhoto(byteArrayOutputStream.toByteArray());
+                bfg.setBean(pojo);
+            } catch (IOException ex) {
+                Logger.getLogger(CustomDisplayTestWithPojo.class.getName()).log(Level.SEVERE, null, ex);
             }
         });
 
-        Button clear = new Button("clear value", new Button.ClickListener() {
-            @Override
-            public void buttonClick(Button.ClickEvent event) {
+        Button clear = new Button("clear value", event -> {
                 pojo.setPhoto(null);
-                bfg = BeanBinder.bind(pojo, CustomDisplayTestWithPojo.this);
-            }
+                bfg.setBean(pojo);
         });
 
-        bfg = BeanBinder.bind(pojo, this);
+        bfg = new Binder<>();
+        bfg.bindInstanceFields(this);
+        bfg.setBean(pojo);
 
-        layout.addComponents(photo, new MHorizontalLayout( button, load, clear));
+        layout.addComponents(photo, new HorizontalLayout( button, load, clear));
         return layout;
     }
 

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/DisabledTest.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/DisabledTest.java
@@ -1,19 +1,17 @@
 package org.vaadin.easyuploads.demoandtestapp;
 
+import java.io.File;
+
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.easyuploads.UploadField;
+
 import com.vaadin.annotations.Theme;
-import com.vaadin.data.Property;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Component;
-import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.Upload;
 import com.vaadin.ui.VerticalLayout;
-import java.io.File;
-
-import org.vaadin.easyuploads.*;
-
-import org.vaadin.addonhelpers.AbstractTest;
 
 @Theme("valo")
 public class DisabledTest extends AbstractTest {
@@ -48,12 +46,7 @@ public class DisabledTest extends AbstractTest {
         file.setButtonCaption("...Select File");
         file.setDisplayUpload(false);
 
-        file.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                Notification.show("File uploaded" + file.getLastFileName() + " IsEmpty:" + file.isEmpty());
-            }
-        });
+        file.addValueChangeListener(event -> Notification.show("File uploaded" + file.getLastFileName() + " IsEmpty:" + file.isEmpty()));
 
         layout.addComponent(file);
         
@@ -68,15 +61,12 @@ public class DisabledTest extends AbstractTest {
  
         CheckBox cb = new CheckBox("Enabled");
         cb.setValue(false);
-        cb.addValueChangeListener(new Property.ValueChangeListener() {
-            @Override
-            public void valueChange(Property.ValueChangeEvent event) {
-                final boolean nextEnabled = !file.isEnabled();
-                file.setEnabled(nextEnabled);
-                wrap.setEnabled(nextEnabled);
-                boolean enabled = upload.isEnabled();
-                Notification.show("Enabled: " + enabled);
-            }
+        cb.addValueChangeListener(event -> {
+            final boolean nextEnabled = !file.isEnabled();
+            file.setEnabled(nextEnabled);
+            wrap.setEnabled(nextEnabled);
+            boolean enabled = upload.isEnabled();
+            Notification.show("Enabled: " + enabled);
         });
         
         layout.addComponents(wrap, cb);

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/MultiFileUploadWithMaxFiles1.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/MultiFileUploadWithMaxFiles1.java
@@ -1,0 +1,31 @@
+package org.vaadin.easyuploads.demoandtestapp;
+
+import java.io.*;
+
+import org.vaadin.easyuploads.*;
+import com.vaadin.ui.*;
+import org.vaadin.addonhelpers.AbstractTest;
+
+public class MultiFileUploadWithMaxFiles1 extends AbstractTest {
+
+    @Override
+    public Component getTestComponent() {
+        VerticalLayout layout = new VerticalLayout();
+        
+        MultiFileUpload multiFileUpload = new MultiFileUpload() {
+            @Override
+            protected void handleFile(File file, String fileName, String mimeType, long length) {
+                Notification.show("File receved");
+            }
+            
+        };
+        multiFileUpload.setMaxFileCount(1);
+        
+        multiFileUpload.setUploadButtonCaption("Upload files...");
+        
+        layout.addComponent(multiFileUpload);
+        
+        return layout;
+    }
+
+}


### PR DESCRIPTION
- Build with Vaadin 8.1.0
- Object replaced by byte[] (so it can be used with vaadin 8 binder)
- Fix bug when ImagePreviewField did not show new image (when using with binder from entity blob byte[])
- Tested with test JavaEE application and its working with binder in AbstractForm without converter etc... (from entity and to entity column)
- Contributors: Tadej Klakočer (tadejk@bass.si), Igor Grenko (igor@bass.si)