### PR TITLE
Replace viritin alpha1 with v7-compatibility package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>8.0.1</version>
+    <version>8.0.1-SNAPSHOT</version>
     <name>EasyUploads</name>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addon</groupId>
     <artifactId>easyuploads</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>8.0.1</version>
     <name>EasyUploads</name>
 
     <organization>
@@ -261,8 +261,8 @@
 
         <dependency>
             <groupId>org.vaadin</groupId>
-            <artifactId>viritin</artifactId>
-            <version>2.0.alpha1</version>
+            <artifactId>viritin-v7-compatibility</artifactId>
+            <version>1.0</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/src/main/java/org/vaadin/easyuploads/UploadField.java
+++ b/src/main/java/org/vaadin/easyuploads/UploadField.java
@@ -36,7 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.vaadin.viritin.v7.label.RichText;
+import org.vaadin.viritinv7.label.RichText;
 
 /**
  * UploadField is a helper class that uses rather low level {@link Upload}

--- a/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
+++ b/src/test/java/org/vaadin/easyuploads/demoandtestapp/CustomDisplayTestWithPojo.java
@@ -11,8 +11,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.vaadin.addonhelpers.AbstractTest;
-import org.vaadin.viritin.v7.BeanBinder;
-import org.vaadin.viritin.v7.MBeanFieldGroup;
+import org.vaadin.viritinv7.BeanBinder;
+import org.vaadin.viritinv7.MBeanFieldGroup;
 import org.vaadin.viritin.layouts.MHorizontalLayout;
 import org.vaadin.viritin.layouts.MVerticalLayout;
 


### PR DESCRIPTION
This avoid import issues in application referencing 'v7-compatibility' and using 'easyuploads' plugin since the packages changed.